### PR TITLE
Use the complete mirrors for xx network

### DIFF
--- a/VueRefactor/serverSide/assets/CoreReposJSON.txt
+++ b/VueRefactor/serverSide/assets/CoreReposJSON.txt
@@ -969,7 +969,7 @@
   },
   {
     "name": "xx network",
-    "url": "https://github.com/Elixxir-io",
+    "url": "https://github.com/xxfoundation",
     "geckoIdentifier": "xxcoin"
   }
 ]


### PR DESCRIPTION
use the complete xx network mirror by the xx foundation instead of the xx messenger-only Elixxir repository mirrors.